### PR TITLE
utilizing jquery's extend function

### DIFF
--- a/blank/jquery.formstyleplus.js
+++ b/blank/jquery.formstyleplus.js
@@ -17,11 +17,7 @@
 				return this;
 			}
 
-			if(!!settings){
-				for (var prop in settings){
-					if(options.hasOwnProperty(prop)){options[prop] = settings[prop]}
-				}
-			}
+			options = $.extend(options, settings);
 
 			var tagname = this.tagName.toLowerCase(),
 				$el = $(this),


### PR DESCRIPTION
This is simpler and likely a tiny bit faster. You don't need to check if settings exists, since it will always exist, and jQuery's extend can handle an undefined case for you. 

You could add a check to confirm settings is an object if it's set to something, but I'd rather cause an error in that case and let the developer fix it. 
